### PR TITLE
Remove legacy android support dependency

### DIFF
--- a/payment-sdk/build.gradle
+++ b/payment-sdk/build.gradle
@@ -49,7 +49,6 @@ dependencies {
     implementation 'com.google.android.gms:play-services-location:20.0.0'
     implementation 'com.google.android.gms:play-services-ads-identifier:18.0.1'
     implementation 'com.google.android.gms:play-services-auth-api-phone:18.0.1'
-    implementation 'com.android.support:appcompat-v7:28.0.0'
     testImplementation 'junit:junit:4.12'
     testImplementation 'com.nhaarman.mockitokotlin2:mockito-kotlin:2.1.0'
     testImplementation 'org.robolectric:robolectric:4.0.2'


### PR DESCRIPTION
Linked issue: https://github.com/network-international/payment-sdk-android/issues/46