### PR TITLE
Detect Jaywan only from the 8th digit

### DIFF
--- a/payment-sdk/src/main/java/payment/sdk/android/cardpayment/card/CardDetector.kt
+++ b/payment-sdk/src/main/java/payment/sdk/android/cardpayment/card/CardDetector.kt
@@ -20,12 +20,20 @@ class CardDetector(private val supportedCards: Set<CardType>) {
                 findMatchingCard = PaymentCard(CardType.Visa, firstSix, findMatchingCard.binRange,
                         findMatchingCard.cvv, findMatchingCard.certainty)
         }
+        // Jaywan shares its short 6690/9784 prefix with a wider space; only commit to
+        // it once 8 digits are entered so it isn't surfaced prematurely.
+        if (findMatchingCard?.type === CardType.Jaywan && bin.length < JAYWAN_MIN_DIGITS) {
+            return null
+        }
         return findMatchingCard
     }
 
     companion object {
 
         private const val LONGEST_AVAILABLE_BIN_DIGITS = 8
+
+        // Jaywan is only detected once this many digits have been entered.
+        private const val JAYWAN_MIN_DIGITS = 8
 
         private fun findMatchingCard(pan: String, acceptedCards: List<CardModel>): PaymentCard? {
             val binValue = pan.toBigInteger()

--- a/payment-sdk/src/test/java/payment/sdk/android/cardpayment/card/CardDetectorTest.kt
+++ b/payment-sdk/src/test/java/payment/sdk/android/cardpayment/card/CardDetectorTest.kt
@@ -45,6 +45,26 @@ class CardDetectorTest {
     }
 
     @Test
+    fun `detect jaywan only from the 8th digit`() {
+        val d = CardDetector(setOf(Visa, MasterCard, Jaywan))
+        // Fewer than 8 digits: not yet resolved to Jaywan.
+        assertNull(d.detect("6690"))
+        assertNull(d.detect("6690123"))
+        assertNull(d.detect("9784"))
+        // 8th digit onwards: Jaywan.
+        assertEquals(Jaywan, d.detect("66901234")?.type)
+        assertEquals(Jaywan, d.detect("6690123456789012")?.type)
+        assertEquals(Jaywan, d.detect("9784000000000000")?.type)
+    }
+
+    @Test
+    fun `jaywan not detected when not in supported cards`() {
+        val d = CardDetector(setOf(Visa, MasterCard))
+        assertNull(d.detect("6690123456789012"))
+        assertNull(d.detect("9784000000000000"))
+    }
+
+    @Test
     fun `detect invalid pans`() {
         assertNull(detector.detect("1111111111111111"))
         assertNull(detector.detect("0000000000000000"))


### PR DESCRIPTION
## Change
`CardDetector` resolved Jaywan from its short 4-digit prefix (`6690`/`9784`), surfacing it prematurely while typing. It now returns `null` for a Jaywan match until **at least 8 digits** are entered.

Adds unit tests: Jaywan is not resolved before the 8th digit, is resolved from the 8th digit onward, and is not detected when Jaywan isn't in the supported cards.

Detection is already scoped to the outlet's supported cards via `CardDetector(supportedCards)`, so no change was needed there. (This mirrors the iOS change in payment-sdk-ios#101.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
